### PR TITLE
Making the WinRAR dependency and install clearer in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,17 @@ WinRAR for Windows. A free evaluation copy can be obtained from [RarLab](http://
 
 ## Installation
 
+WinRAR must be installed for this gem to work.
+
+### Installing WinRAR for Mac
+
+* [Download the installer](http://www.techspot.com/downloads/5169-winrar-for-mac.html) files and extract.
+* Copy the file titled 'rar' into a folder that's in your `$PATH` such as `/usr/local/bin`. If you're not sure what folders are in your path, run `echo $PATH`.
+* Open a new terminal window and test installation by running `rar`. If you see information about WinRAR, it installed correctly.
+
+
+### Install the gem
+
 `gem install rar`
 
 And you're all set. Extra dependencies will automatically be installed.


### PR DESCRIPTION
I lost a good part of an afternoon to ultimately find out I needed to install WinRAR. This might have been obvious if I read closer but I figured I'd make this clearer for anyone else who might not have caught that detail.

Thanks for the nice gem!